### PR TITLE
Imported and rename latest Prometheus library

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -3,23 +3,37 @@ name: Run-Tests
 on: [pull_request]
 
 jobs:
-  run-tests:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.8]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: python3 -m pip install tox
+    - name: Run linters
+      run: tox -vve lint
+  unit-test:
+    name: Unit tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8]
-
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: python -m pip install -r requirements-dev.txt
-
-
-      - name: Run tests
-        run: ./run_tests
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: python -m pip install tox
+    - name: Run tests
+      run: tox -e unit

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,7 +13,7 @@ implements a relation to the PostgreSQL charm.
 
 import logging
 
-from charms.prometheus_k8s.v0.prometheus import MetricsEndpointAggregator
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointAggregator
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main


### PR DESCRIPTION
This commit imports and renames the latest Prometheus library
from the Prometheus Operator github repository. Note that
this version of the Prometheus library has not yet been
released to Charmhub since charmcraft as yet does not
support library name changes. Creating a new library with
a different name is not advised since it is expected that
a specific library will always retain the same library ID.
